### PR TITLE
update the manifest dependency_repository_url

### DIFF
--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -16,6 +16,9 @@
   "identifier": "JWPlayer-Plugin-iOS",
   "dependency_name": "JWPlayer-Plugin-iOS",
   "dependency_version": "0.1.0",
+  "dependency_repository_url": [
+      "git@github.com:applicaster/JWPlayerSDKWrapper-iOS/Specs.git"
+  ],
   "whitelisted_account_ids": [
 
   ],


### PR DESCRIPTION
source url for the SDK subspec is used when the plugin is being added to the app, actually it is being added to the app podfile the same way as you have it in the plugin podfile.