### PR TITLE
Enable prehooks in the player

### DIFF
--- a/JWPlayerPlugin.podspec
+++ b/JWPlayerPlugin.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name             = "JWPlayerPlugin"
-  s.version          = '3.0.0'
+  s.version          = '3.1.0'
   s.summary          = 'JWPlayer Player plugin implementation.'
   s.description      = 'An implementation for JWPlayer as a Zapp Player Plugin in Objective C.'
   s.homepage         = "https://github.com/applicaster/JWPlayer-Plugin-iOS"

--- a/JWPlayerPlugin/ZappJWPlayerAdapter.h
+++ b/JWPlayerPlugin/ZappJWPlayerAdapter.h
@@ -14,7 +14,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface ZappJWPlayerAdapter : NSObject <ZPPlayerProtocol>
+@interface ZappJWPlayerAdapter : NSObject <ZPPlayerProtocol, ZPPluggableScreenProtocol>
 
 @property (nonatomic, strong) JWPlayerViewController *playerViewController;
 @property (nonatomic, strong) NSObject<ZPPlayable> *currentPlayableItem;

--- a/JWPlayerPlugin/ZappJWPlayerAdapter.m
+++ b/JWPlayerPlugin/ZappJWPlayerAdapter.m
@@ -13,6 +13,8 @@
 
 @implementation ZappJWPlayerAdapter
 
+@synthesize screenPluginDelegate;
+
 static NSString *const kPlayableItemsKey = @"playable_items";
 
 #pragma mark - ZPPlayerProtocol
@@ -306,4 +308,12 @@ static NSString *const kPlayableItemsKey = @"playable_items";
         completion();
     }
 }
+
+#pragma mark - ZPPluggableScreenProtocol / ZPUIBuilderPluginsProtocol
+
+//Necessary to implement this method to allow prehooks, however this constructor is never called for a player
+- (instancetype)initWithPluginModel:(ZPPluginModel *)pluginModel screenModel:(ZLScreenModel *)screenModel dataSourceModel:(NSObject *)dataSourceModel {
+    return nil;
+}
+
 @end

--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -8,15 +8,15 @@
   "platform": "ios",
   "author_name": "Marcos Reyes",
   "author_email": "m.reyes@applicaster.com",
-  "manifest_version": "3.0.0",
+  "manifest_version": "3.1.0",
   "name": "JWPlayer",
   "description": "JW Player Plugin for Applicaster Zapp Platform",
   "type": "player",
-  "screen": false,
+  "screen": true,
   "identifier": "JWPlayer-Plugin-iOS",
   "ui_builder_support": true,
   "dependency_name": "JWPlayerPlugin",
-  "dependency_version": "3.0.0",
+  "dependency_version": "3.1.0",
   "whitelisted_account_ids": [],
   "min_zapp_sdk": "11.0.0-Dev",
   "deprecated_since_zapp_sdk": "",
@@ -68,5 +68,21 @@
       "key": "vod_ad_type",
       "tooltip_text": "VOD ad type"
     }
-  ]
+  ],
+  "hooks": {
+    "fields": [
+      {
+        "group": true,
+        "label": "Before Load",
+        "folded": true,
+        "fields": [
+          {
+            "key": "preload_plugins",
+            "type": "preload_plugins_selector",
+            "label": "Select Plugins"
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
For a player to have prehooks configured, it needs to be implementing the ZPPluggableScreenProtocol, this is because to configure the hooks you need to add it as a screen in uibuilder (even if the player will not be used as a screen).