### PR TITLE
Fix: player not playing because model didn't load urlstrem after login

### DIFF
--- a/JWPlayerPlugin.podspec
+++ b/JWPlayerPlugin.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name             = "JWPlayerPlugin"
-  s.version          = '3.0.0'
+  s.version          = '3.0.1'
   s.summary          = 'JWPlayer Player plugin implementation.'
   s.description      = 'An implementation for JWPlayer as a Zapp Player Plugin in Objective C.'
   s.homepage         = "https://github.com/applicaster/JWPlayer-Plugin-iOS"

--- a/JWPlayerPlugin/Info.plist
+++ b/JWPlayerPlugin/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0</string>
+	<string>3.0.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/JWPlayerPlugin/ZappJWPlayerAdapter.m
+++ b/JWPlayerPlugin/ZappJWPlayerAdapter.m
@@ -302,6 +302,19 @@ static NSString *const kPlayableItemsKey = @"playable_items";
             blockSelf.currentPlayableItem = (NSObject <ZPPlayable>*)model;
             completion();
         }];
+    } else if ([[self currentPlayableItem] isKindOfClass:[APAtomEntryPlayable class]] && ![self.currentPlayableItem.contentVideoURLPath isNotEmptyOrWhiteSpaces])  {
+        APAtomEntryPlayable *model = (APAtomEntryPlayable *)[self currentPlayableItem];
+        NSNumber *channelID = model.extensionsDictionary[@"applicaster_channel_id"];
+        APChannel *channel = [[APApplicasterController sharedInstance].account channelByUniqueID:[channelID stringValue]];
+        if (channel) {
+            __block typeof(self) blockSelf = self;
+            [channel loadWithCompletionHandler:^(BOOL success, APModel *model) {
+                blockSelf.currentPlayableItem = (NSObject <ZPPlayable>*)model;
+                completion();
+            }];
+        } else {
+            completion();
+        }
     } else {
         completion();
     }


### PR DESCRIPTION
When we are trying to play a stream that requires authentication, it is not playing, because the urlstream is empty.

There was logic to handle this case, but not when the content comes from a feed.