### PR TITLE
The manifest was using a wrong id

### DIFF
--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -13,7 +13,7 @@
   "description": "JW Player Plugin for Applicaster Zapp Platform",
   "type": "player",
   "screen": true,
-  "identifier": "JWPlayer-Plugin-iOS",
+  "identifier": "JWPlayer-Plugin",
   "ui_builder_support": true,
   "dependency_name": "JWPlayerPlugin",
   "dependency_version": "3.1.3",


### PR DESCRIPTION
JW player iOS versions 3.1.1 and 3.1.2 have an invalid identifier in their manifest. The identifier should be JWPlayer-Plugin and not JWPlayer-Plugin-iOS. We use the same identifier for iOS and for Android.
This bug is causing prehooks to don’t work.