### PR TITLE
Ads fix

### DIFF
--- a/JWPlayerPlugin.podspec
+++ b/JWPlayerPlugin.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name             = "JWPlayerPlugin"
-  s.version          = '3.1.4'
+  s.version          = '3.1.5'
   s.summary          = 'JWPlayer Player plugin implementation.'
   s.description      = 'An implementation for JWPlayer as a Zapp Player Plugin in Objective C.'
   s.homepage         = "https://github.com/applicaster/JWPlayer-Plugin-iOS"

--- a/JWPlayerPlugin/Info.plist
+++ b/JWPlayerPlugin/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.3</string>
+	<string>3.1.5</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/JWPlayerPlugin/JWPlayerViewController.m
+++ b/JWPlayerPlugin/JWPlayerViewController.m
@@ -114,8 +114,23 @@
                 adConfig.adVmap = adConfiguration[@"ad_url"];
                 break;
             } else {
-                // We need to schedule the ads
-                JWAdBreak *adBreak = [self createAdBreakWithTag:adConfiguration[@"ad_url"] offset:adConfiguration[@"offset"]];
+                NSObject *rawOffset = adConfiguration[@"offset"];
+                NSString *convertedOffset = nil;
+                
+                if ([rawOffset isKindOfClass:NSString.class]) {
+                    NSString *offset = (NSString *)rawOffset;
+                    if ([offset isEqualToString:@"preroll"]) {
+                        convertedOffset = @"pre";
+                    }
+                    else if ([offset isEqualToString:@"postroll"]) {
+                        convertedOffset = @"post";
+                    }
+                }
+                else if ([rawOffset isKindOfClass:NSNumber.class]) {
+                    convertedOffset = [(NSNumber *)rawOffset stringValue];
+                }
+                
+                JWAdBreak *adBreak = [self createAdBreakWithTag:adConfiguration[@"ad_url"] offset:convertedOffset];
                 
                 if (adBreak) {
                     [scheduleArray addObject:adBreak];

--- a/JWPlayerPlugin/ZappJWPlayerAdapter.m
+++ b/JWPlayerPlugin/ZappJWPlayerAdapter.m
@@ -209,10 +209,14 @@ static NSString *const kPlayableItemsKey = @"playable_items";
 - (void)setupPlayerWithCurrentPlayableItem {
     [self.playerViewController setupPlayerWithPlayableItem:self.currentPlayableItem];
     self.playerViewController.isLive = [self.currentPlayableItem isKindOfClass:[APChannel class]];
+
+    NSArray *ads = self.currentPlayableItem.extensionsDictionary[@"videoAds"];
+    if (ads == nil) {
+        ads = self.currentPlayableItem.extensionsDictionary[@"video_ads"];
+    }
     
     // Setup Ads
-    NSArray *adsArray = self.currentPlayableItem.extensionsDictionary[@"videoAds"];
-    [self.playerViewController setupPlayerAdvertisingWithConfiguration:adsArray];
+    [self.playerViewController setupPlayerAdvertisingWithConfiguration:ads];
 
     // Setup Subtitle Tracks if provided
     NSArray *subtitleTracksArray = self.currentPlayableItem.extensionsDictionary[@"sideCarCaptions"];


### PR DESCRIPTION
- Align the jw plug usage of an atom entry playable with the applicaster ads format
- https://developer.applicaster.com/player/ads-in-datasource.html